### PR TITLE
* Toolbar: Give this a z-index

### DIFF
--- a/toolbar.css
+++ b/toolbar.css
@@ -1,6 +1,7 @@
 .reveal .reveal-toolbar {
     position: absolute;
     left: 30px;
+    z-index: 100;
 }
 
 .reveal .reveal-toolbar.reveal-toolbar-bottom {


### PR DESCRIPTION
It's necessary to set the z-index so that this can be clicked on if there was an "overlapping" image on top of it.