### PR TITLE
fix Uncaught ReferenceError: XXXX is not defined

### DIFF
--- a/toolbar.js
+++ b/toolbar.js
@@ -137,7 +137,7 @@ var RevealToolbar =
 
         if (showNotes && !Reveal.isSpeakerNotes()) {
           createToolbarButton('fa-list-alt', function() {
-            if (RevealNotes) {
+            if (window.RevealNotes) {
               RevealNotes.open();
             }
           });

--- a/toolbar.js
+++ b/toolbar.js
@@ -186,7 +186,7 @@ var RevealToolbar =
         if (captureMenu) {
           // handle async loading of plugins
           var id_menu = setInterval(function() {
-            if (RevealMenu && RevealMenu.isInit()) {
+            if (window.RevealMenu && RevealMenu.isInit()) {
               dom.menu = document.querySelector('div.slide-menu-button');
               if (dom.menu) {
                 console.log('Moving menu button');

--- a/toolbar.js
+++ b/toolbar.js
@@ -243,7 +243,7 @@ var RevealToolbar =
               JSON.stringify({
                 namespace: 'reveal',
                 eventName: type,
-                state: getState()
+                state: Reveal.getState()
               }),
               '*'
             );


### PR DESCRIPTION
Hi and thank you for this awesome toolbar!!

Tried it for myself and got bumped into 3 issues so here's the fix!

"ReferenceError: RevealMenu is not defined"

![image](https://user-images.githubusercontent.com/1901827/82267203-f2aa0300-996b-11ea-9a84-7ac274a4df3f.png)

"ReferenceError: RevealNotes is not defined"

![image](https://user-images.githubusercontent.com/1901827/82268781-1b33fc00-9970-11ea-8573-5c2c9593fa27.png)

"ReferenceError: getState is not defined"

![image](https://user-images.githubusercontent.com/1901827/82273288-67396d80-997d-11ea-88e9-84d5182a7a44.png)

These 3 commits are fixing these issues.

Thank you :-)

