### PR TITLE
Rename RevealMenu function "isInit" to "isMenuInitialised"

### DIFF
--- a/toolbar.js
+++ b/toolbar.js
@@ -186,7 +186,7 @@ var RevealToolbar =
         if (captureMenu) {
           // handle async loading of plugins
           var id_menu = setInterval(function() {
-            if (RevealMenu && RevealMenu.isInit()) {
+            if (RevealMenu && RevealMenu.isMenuInitialised()) {
               dom.menu = document.querySelector('div.slide-menu-button');
               if (dom.menu) {
                 console.log('Moving menu button');


### PR DESCRIPTION
Based on:
https://github.com/denehyg/reveal.js-menu/commit/67396df76b0c528c9e60f6355eba573549e10f18

This function name update is merely to be in sync with the README.MD at [reveal.js-menu](https://github.com/denehyg/reveal.js-menu) repository.

---

`menu.js` at [reveal.js-menu](https://github.com/denehyg/reveal.js-menu) repository is minimized; apparently, this is why at execution time causes an error when calling the function by its name.

If you grep in search for `isMenuInitialised` through [reveal.js-menu](https://github.com/denehyg/reveal.js-menu) repository, can only be found as an update description at README.MD, but not at any JS file.